### PR TITLE
Clarify coordinate format in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Example: distance between Boston and New York City
 .. code:: python
 
    >>> from vincenty import vincenty
-   >>> boston = (42.3541165, -71.0693514)
+   >>> boston = (42.3541165, -71.0693514)  # note coordinates are specified as (lat, lon) or (y, x)
    >>> newyork = (40.7791472, -73.9680804)
    >>> vincenty(boston, newyork)
    298.396057


### PR DESCRIPTION
This update will add a comment to the example code in the README to indicate the format that the `vincenty` function is expecting for the coordinates. 

Many GIS applications use `(x, y)` order and it isn't clear even from reading the function definition whether the coordinates should be in `(lat, lon)` or `(lon, lat)` format.

This README update will remove any ambiguity and might save others from potentially taking a measurement that they did not intend; frequently, a mistake like will not cause any error or failure.